### PR TITLE
Bump to 0.5.2 to handle downed nodes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    codeclimate-kafka (0.5.1)
+    codeclimate-kafka (0.5.2)
       bson (~> 1.12.2)
       bson_ext (~> 1.12.2)
       codeclimate-poseidon (~> 0.0.7)

--- a/lib/cc/kafka/version.rb
+++ b/lib/cc/kafka/version.rb
@@ -1,5 +1,5 @@
 module CC
   module Kafka
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end


### PR DESCRIPTION
@codeclimate/review 

Bumping codeclimate-kafka to use codeclimate
forked copy of poseidon gem that incorporates
better messaging and hadnling of unavailable leaders
when a node is down.

Changes to poseidon gem:
https://github.com/bpot/poseidon/compare/master...drcapulet:alexc-handle-errors

Reference in codeclimate-poseidon gem
https://github.com/codeclimate/poseidon/commit/fdfa4e2f02865f3fdf24de45cd9560f4652d425a
