### PR TITLE
require kafka to acknowledge writes

### DIFF
--- a/lib/cc/kafka/producer/poseidon.rb
+++ b/lib/cc/kafka/producer/poseidon.rb
@@ -27,7 +27,8 @@ module CC
           @producer ||= ::Poseidon::Producer.new(
             @brokers,
             @client_id,
-            compression_codec: :gzip
+            compression_codec: :gzip,
+            required_acks: -1,
           )
         end
       end

--- a/spec/cc/kafka/producer/poseidon_spec.rb
+++ b/spec/cc/kafka/producer/poseidon_spec.rb
@@ -14,7 +14,7 @@ class CC::Kafka::Producer
           with([poseidon_message])
 
         expect(::Poseidon::Producer).to receive(:new).
-          with(["host:1234"], "a-client-id", compression_codec: :gzip).
+          with(["host:1234"], "a-client-id", compression_codec: :gzip, required_acks: -1).
           and_return(poseidon_producer)
 
         producer = Poseidon.new("host", 1234, "a-topic", "a-client-id")


### PR DESCRIPTION
We theorize that our kafka crash earlier today was made worse by not
requiring kafka to acknowledge & agree on writes.

This setting is the strongest level of durability: kafka doesn't
acknowledge the the message until all replicas are in sync. (Kafka docs:
https://kafka.apache.org/08/configuration.html).

This may not be what we want (for example, I'm not sure what happens with this setting when a
kafka node goes down: does the cluster acknowledge writes when all
remaining nodes agree, or does it just stop acknowledging altogether?).
But I'm pretty sure we don't want the default either.

I have not tested this locally, but will do so to make sure this doesn't break with existing stuff.

Thoughts, @codeclimate/review?
