### PR TITLE
Pass kafka message if on_message block takes 2 args

### DIFF
--- a/lib/cc/kafka/consumer.rb
+++ b/lib/cc/kafka/consumer.rb
@@ -79,7 +79,11 @@ module CC
                 message.offset,
               ].join("-")
 
-              @on_message.call(data)
+              if @on_message.arity == 2
+                @on_message.call(data, message)
+              else
+                @on_message.call(data)
+              end
             end
           end
           Kafka.statsd.increment("messages.processed")


### PR DESCRIPTION
Necessary for better logging in Scheduler. Couldn't find a quick and easy way to test this so punted, but the conditional is designed so there will be no impact unless `@on_message.arity == 2`, which it is not in any current use cases.

/c @pbrisbin 