### PR TITLE
Add on-start/stop hook methods

### DIFF
--- a/lib/cc/kafka/consumer.rb
+++ b/lib/cc/kafka/consumer.rb
@@ -35,13 +35,9 @@ module CC
       end
 
       def start
-        trap(:TERM) do
-          @on_stop.call(@offset) if @on_stop
-          stop
-        end
+        trap(:TERM) { stop }
 
         @running = true
-
         @on_start.call(@offset) if @on_start
 
         while @running do
@@ -50,6 +46,8 @@ module CC
 
         Kafka.logger.info("shutting down due to TERM signal")
       ensure
+        @on_stop.call(@offset) if @on_stop
+
         close
       end
 

--- a/lib/cc/kafka/consumer.rb
+++ b/lib/cc/kafka/consumer.rb
@@ -36,13 +36,13 @@ module CC
 
       def start
         trap(:TERM) do
-          @on_stop.call if @on_stop
+          @on_stop.call(@offset) if @on_stop
           stop
         end
 
         @running = true
 
-        @on_start.call if @on_start
+        @on_start.call(@offset) if @on_start
 
         while @running do
           fetch_messages

--- a/lib/cc/kafka/consumer.rb
+++ b/lib/cc/kafka/consumer.rb
@@ -22,14 +22,27 @@ module CC
         )
       end
 
+      def on_start(&block)
+        @on_start = block
+      end
+
+      def on_stop(&block)
+        @on_stop = block
+      end
+
       def on_message(&block)
         @on_message = block
       end
 
       def start
-        trap(:TERM) { stop }
+        trap(:TERM) do
+          @on_stop.call if @on_stop
+          stop
+        end
 
         @running = true
+
+        @on_start.call if @on_start
 
         while @running do
           fetch_messages


### PR DESCRIPTION
We're going to be implementing locking around the kafka-offset records. While
we eventually want to move away from this gem entirely, the path of least
resistance at the moment is to add these small hook methods so we can acquire
and release the lock on start and stop respectively.

/cc @codeclimate/review