### PR TITLE
Add ability to pause a consumer.

### DIFF
--- a/lib/cc/kafka/consumer.rb
+++ b/lib/cc/kafka/consumer.rb
@@ -20,6 +20,7 @@ module CC
           @offset.partition,
           current_offset(@offset)
         )
+        @paused = false
       end
 
       def on_start(&block)
@@ -41,7 +42,7 @@ module CC
         @on_start.call(@offset) if @on_start
 
         while @running do
-          fetch_messages
+          fetch_messages unless @paused
         end
 
         Kafka.logger.info("shutting down due to TERM signal")
@@ -53,6 +54,14 @@ module CC
 
       def stop
         @running = false
+      end
+
+      def pause
+        @paused = true
+      end
+
+      def unpause
+        @paused = false
       end
 
       def fetch

--- a/spec/cc/kafka/consumer_spec.rb
+++ b/spec/cc/kafka/consumer_spec.rb
@@ -36,6 +36,23 @@ module CC::Kafka
       end
     end
 
+    describe "pausing" do
+      it "pauses fetching messages" do
+        poseidon_consumer = double("PartitionConsumer")
+        expect(poseidon_consumer).to receive(:close)
+        allow(poseidon_consumer).to receive(:fetch).and_return([])
+        allow(Poseidon::PartitionConsumer).to receive(:consumer_for_partition).
+          and_return(poseidon_consumer)
+
+        consumer = Consumer.new("a-client-id", %w[seed brokers], "a-topic", "a-partition")
+
+        expect(consumer).to receive(:fetch_messages).never
+
+        consumer.pause
+        run_consumer(consumer)
+      end
+    end
+
     # This is arguably a hack, but it does also test the graceful stop behavior
     def run_consumer(consumer)
       Thread.new { sleep 0.1 and consumer.stop }


### PR DESCRIPTION
A paused consumer will not fetch new messages, but will remain open and
running.

@codeclimate/review 